### PR TITLE
Changes to support phpunit 9.x from Debian

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,12 +1,13 @@
-<phpunit bootstrap="test/Horde/Auth/bootstrap.php" colors="true">
+<?xml version="1.0"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="test/Horde/Auth/bootstrap.php" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">lib</directory>
+    </include>
+  </coverage>
   <testsuites>
-    <testsuite>
+    <testsuite name="Horde Auth Unit Tests">
       <directory>test</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">lib</directory>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/test/Horde/Auth/Unit/KolabTest.php
+++ b/test/Horde/Auth/Unit/KolabTest.php
@@ -13,6 +13,7 @@
  * @author     Gunnar Wrobel <wrobel@pardus.de>
  * @license    http://www.horde.org/licenses/lgpl21 LGPL-2.1
  */
+#[\AllowDynamicProperties]
 class Horde_Auth_Unit_KolabTest extends Horde_Auth_TestCase
 {
     public function setUp(): void

--- a/test/Horde/Auth/Unit/KolabTest.php
+++ b/test/Horde/Auth/Unit/KolabTest.php
@@ -15,12 +15,13 @@
  */
 class Horde_Auth_Unit_KolabTest extends Horde_Auth_TestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         if (!interface_exists('Horde_Kolab_Session')) {
             $this->markTestSkipped('The Kolab_Session package is apparently not installed (Interface Horde_Kolab_Session is unavailable).');
         }
-        $this->kolab = $this->getMock('Horde_Kolab_Session');
+        $this->kolab = $this->getMockBuilder('Horde_Kolab_Session')
+                            ->getMock();
         $this->driver = new Horde_Auth_Kolab(array('kolab' => $this->kolab));
     }
 

--- a/test/Horde/Auth/Unit/PasswdTest.php
+++ b/test/Horde/Auth/Unit/PasswdTest.php
@@ -14,6 +14,7 @@
  * @author     Gunnar Wrobel <wrobel@pardus.de>
  * @license    http://www.horde.org/licenses/lgpl21 LGPL-2.1
  */
+#[\AllowDynamicProperties]
 class Horde_Auth_Unit_PasswdTest extends Horde_Auth_TestCase
 {
     public function setUp(): void

--- a/test/Horde/Auth/Unit/PasswdTest.php
+++ b/test/Horde/Auth/Unit/PasswdTest.php
@@ -16,7 +16,7 @@
  */
 class Horde_Auth_Unit_PasswdTest extends Horde_Auth_TestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         $this->driver = new Horde_Auth_Passwd(
             array('filename' => __DIR__ . '/../fixtures/test.passwd')

--- a/test/Horde/Auth/Unit/Sql/Base.php
+++ b/test/Horde/Auth/Unit/Sql/Base.php
@@ -15,7 +15,7 @@ class Horde_Auth_Unit_Sql_Base extends Horde_Auth_TestCase
 
     protected static $reason;
 
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         $dir = __DIR__ . '/../../../../../migration/Horde/Auth';
         if (!is_dir($dir)) {
@@ -42,7 +42,7 @@ class Horde_Auth_Unit_Sql_Base extends Horde_Auth_TestCase
         self::$db->execute($row);
     }
 
-    public static function tearDownAfterClass()
+    public static function tearDownAfterClass(): void
     {
         if (self::$migrator) {
             self::$migrator->down();
@@ -54,7 +54,7 @@ class Horde_Auth_Unit_Sql_Base extends Horde_Auth_TestCase
         parent::tearDownAfterClass();
     }
 
-    public function setUp()
+    public function setUp(): void
     {
         if (!self::$db) {
             $this->markTestSkipped(self::$reason);

--- a/test/Horde/Auth/Unit/Sql/Locks.php
+++ b/test/Horde/Auth/Unit/Sql/Locks.php
@@ -18,7 +18,7 @@ class Horde_Auth_Unit_Sql_Locks extends Horde_Auth_Unit_Sql_Base
 
     protected static $skip = '';
 
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         parent::setUpBeforeClass();
 
@@ -47,7 +47,7 @@ class Horde_Auth_Unit_Sql_Locks extends Horde_Auth_Unit_Sql_Base
 
     }
 
-    public function setUp()
+    public function setUp(): void
     {
         if (!class_exists('Horde_Db')) {
             $this->markTestSkipped('The Horde_Db package is not installed!');
@@ -77,14 +77,13 @@ class Horde_Auth_Unit_Sql_Locks extends Horde_Auth_Unit_Sql_Base
     public function testLockUserOnceWorks()
     {
         self::$auth->lockUser('konqui');
+        // we didn't fail above, then assert 'true' here...
+        $this->assertTrue(true);
     }
-
-    /**
-     * @expectedException Horde_Auth_Exception
-     */
 
     public function testLockUserTwiceFails()
     {
+        $this->expectException('Horde_Auth_Exception');
         self::$auth->lockUser('konqui');
         self::$auth->lockUser('konqui');
     }
@@ -111,6 +110,8 @@ class Horde_Auth_Unit_Sql_Locks extends Horde_Auth_Unit_Sql_Base
         self::$auth->unlockUser('konqui');
         self::$auth->unlockUser('konqui');
         self::$auth->unlockUser('konqui');
+        // we didn't fail above, then assert 'true' here...
+        $this->assertTrue(true);
     }
 
 }

--- a/test/Horde/Auth/Unit/Sql/Pdo/SqliteLockTest.php
+++ b/test/Horde/Auth/Unit/Sql/Pdo/SqliteLockTest.php
@@ -12,7 +12,7 @@ require_once __DIR__ . '/../Locks.php';
 
 class Horde_Auth_Unit_Sql_Pdo_SqliteLockTest extends Horde_Auth_Unit_Sql_Locks
 {
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         $factory_db = new Horde_Test_Factory_Db();
 

--- a/test/Horde/Auth/Unit/Sql/Pdo/SqliteTest.php
+++ b/test/Horde/Auth/Unit/Sql/Pdo/SqliteTest.php
@@ -12,7 +12,7 @@ require_once __DIR__ . '/../Base.php';
 
 class Horde_Auth_Unit_Sql_Pdo_SqliteTest extends Horde_Auth_Unit_Sql_Base
 {
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         $factory_db = new Horde_Test_Factory_Db();
 


### PR DESCRIPTION
- Debian changes: Adapt to PHPUnit 8.x and 9.x API. https://salsa.debian.org/horde-team/php-horde-auth/-/blob/debian-sid/debian/patches/1010_phpunit-8.x%2B9.x.patch
- Debian changes: Fix PHP 8.2 deprecation warnings. https://salsa.debian.org/horde-team/php-horde-auth/-/blob/debian-sid/debian/patches/1012_php8.2.patch
