### PR TITLE
fix: The 'login' driver does not use the binary path

### DIFF
--- a/lib/Horde/Auth/Login.php
+++ b/lib/Horde/Auth/Login.php
@@ -71,7 +71,7 @@ class Horde_Auth_Login extends Horde_Auth_Base
             throw new Horde_Auth_Exception('', Horde_Auth::REASON_BADLOGIN);
         }
 
-        $proc = @popen($this->_location . ' -c /bin/true ' . $userId, 'w');
+        $proc = @popen($this->_params['location'] . ' -c /bin/true ' . $userId, 'w');
         if (!is_resource($proc)) {
             throw new Horde_Auth_Exception('', Horde_Auth::REASON_FAILED);
         }


### PR DESCRIPTION
https://bugs.horde.org/ticket/?searchfield=15030
Access to a property which does not exist. When changing this to the parameters array the driver starts working on Ubuntu 22.04.